### PR TITLE
fix: keep only the first value found in Find-7ZipExe

### DIFF
--- a/powershell/DevolutionsLabs.psm1
+++ b/powershell/DevolutionsLabs.psm1
@@ -254,7 +254,7 @@ function Test-DLabVM
 
 function Find-7ZipExe {
     $7ZipExe = Get-Command -Name 7z -CommandType Application -ErrorAction SilentlyContinue |
-        Select-Object -ExpandProperty Source
+        Select-Object -ExpandProperty Source -First 1
     if (-Not $7ZipExe) {
         $7ZipExe = @(
             "${Env:ProgramFiles}\7-Zip\7z.exe",


### PR DESCRIPTION
When several 7zip binaries are installed, we should only keep one of them. I arbitrarily decided to take the first one.