### PR TITLE
Prevent dnsmasq from assigning broadcast address to clients

### DIFF
--- a/powershell/common.ps1
+++ b/powershell/common.ps1
@@ -28,7 +28,7 @@ $RTRVMNumber = 2
 $RTRIpAddress = Get-DLabIpAddress $LabNetworkBase $RTRVMNumber
 $DefaultGateway = $RTRIpAddress
 $DhcpRangeStart = Get-DLabIpAddress $LabNetworkBase 100
-$DhcpRangeEnd = Get-DLabIpAddress $LabNetworkBase 255
+$DhcpRangeEnd = Get-DLabIpAddress $LabNetworkBase 254
 
 $DomainName = "ad.$LabName"
 $DnsZoneName = $DomainName


### PR DESCRIPTION
Assigning the broadcast IP address to clients breaks their connectivity. Changes DHCP range end from 255 to 254.